### PR TITLE
Fix slide matching for png, gif, and bmp files.

### DIFF
--- a/lib/cinemavision/content.py
+++ b/lib/cinemavision/content.py
@@ -468,9 +468,9 @@ class TriviaDirectoryHandler:
     _clueNA = ('clue', 'format')
     _answerNA = ('answer', 'format')
 
-    _defaultQRegEx = '_q\.jpg|png|gif|bmp'
-    _defaultCRegEx = '_c(\d)?\.jpg|png|gif|bmp'
-    _defaultARegEx = '_a\.jpg|png|gif|bmp'
+    _defaultQRegEx = '_q\.(jpg|png|gif|bmp)'
+    _defaultCRegEx = '_c(\d)?\.(jpg|png|gif|bmp)'
+    _defaultARegEx = '_a\.(jpg|png|gif|bmp)'
 
     def __init__(self, callback=None):
         self._callback = callback


### PR DESCRIPTION
I have QA trivia slides that were not finding their way into the content database despite following the default format. It turns out that both the question and answer slides were matching the default question regular expression since they included the string 'png'. The | part of the regular expressions needs to be inside a group containing only the different extensions in order to work as desired.