### PR TITLE
Colons erroring iTunes scraper

### DIFF
--- a/lib/cinemavision/scrapers/itunes/scraper.py
+++ b/lib/cinemavision/scrapers/itunes/scraper.py
@@ -150,7 +150,7 @@ class TrailerScraper(object):
             return
 
         for li in tree.findAll('li', {'class': re.compile('trailer')}):
-            slug = li.find('h3').string.replace(' ', '').replace('-', '').lower()
+            slug = li.find('h3').string.replace(' ', '').replace('-', '').replace(':','').lower()
             playlist = self.__get_url(self.PLAY_LIST_URL % (location, slug))
             trailer_url = re.search(self.RE_URL, playlist).group(1)
             duration = int(re.search(self.RE_DURATION, playlist).group(1)) / 1000


### PR DESCRIPTION
I was getting a 404 error when the iTunes scraper was trying to load the Kung Fu Panda 3 trailers, I checked the trailer url (http://trailers.apple.com/trailers/fox/kungfupanda3/includes/playlists/web.inc) and there was a "Clip: Kai Arrives" video which was generating the playlist url: http://trailers.apple.com/trailers/fox/kungfupanda3/itsxml/26-clip:kaiarrives.xml which errors with the colon.

I changed the scraper script to remove the colon when generating the url.