### PR TITLE
Use filename for Atmos/DTS-X detection

### DIFF
--- a/lib/cinemavision/sequenceprocessor.py
+++ b/lib/cinemavision/sequenceprocessor.py
@@ -1,5 +1,6 @@
 import os
 import random
+import re
 import time
 import datetime
 import database as DB
@@ -1059,6 +1060,22 @@ class VideoBumperHandler:
 
 
 class AudioFormatHandler:
+    _atmosRegex = re.compile('[._ -]Atmos[._ -]', re.IGNORECASE)
+    _dtsxRegex = re.compile('[._ -]DTS[._ -]X[._ -]', re.IGNORECASE)
+
+    def _checkFileNameForFormat(self, feature):
+        featureFileName = os.path.basename(feature.path)
+        
+        if feature.audioFormat == 'Dolby TrueHD' and re.search(self._atmosRegex, featureFileName):
+            util.DEBUG_LOG('    - Detect: Used file path {0} to determine audio format is {1}'.format(featureFileName, 'Dolby Atmos'))
+            return 'Dolby Atmos'
+        elif feature.audioFormat == 'DTS-HD Master Audio' and re.search(self._dtsxRegex, featureFileName):
+            util.DEBUG_LOG('    - Detect: Used file path {0} to determine audio format is {1}'.format(featureFileName, 'DTS-X'))
+            return 'DTS-X'
+        else:
+            util.DEBUG_LOG('    - Detect: Looked at the file path {0} and decided to keep audio format {1}'.format(featureFileName, repr(feature.audioFormat)))
+            return feature.audioFormat
+    
     @DB.session
     def __call__(self, caller, sItem):
         bumper = None
@@ -1072,11 +1089,12 @@ class AudioFormatHandler:
 
         if method == 'af.detect':
             util.DEBUG_LOG('    - Detect')
-            if caller.nextQueuedFeature.audioFormat:
+            audioFormat = self._checkFileNameForFormat(caller.nextQueuedFeature)
+            if audioFormat:
                 try:
                     bumper = random.choice(
                         [x for x in DB.AudioFormatBumpers.select().where(
-                            (DB.AudioFormatBumpers.format == caller.nextQueuedFeature.audioFormat) & (DB.AudioFormatBumpers.is3D == is3D)
+                            (DB.AudioFormatBumpers.format == audioFormat) & (DB.AudioFormatBumpers.is3D == is3D)
                         )]
                     )
                     util.DEBUG_LOG('    - Detect: Using bumper based on feature codec info ({0})'.format(repr(caller.nextQueuedFeature.title)))
@@ -1085,7 +1103,7 @@ class AudioFormatHandler:
                     if is3D and util.getSettingDefault('bumper.fallback2D'):
                         try:
                             bumper = random.choice(
-                                [x for x in DB.AudioFormatBumpers.select().where(DB.AudioFormatBumpers.format == caller.nextQueuedFeature.audioFormat)]
+                                [x for x in DB.AudioFormatBumpers.select().where(DB.AudioFormatBumpers.format == audioFormat)]
                             )
                             util.DEBUG_LOG(
                                 '    - Using bumper based on feature codec info and falling back to 2D ({0})'.format(repr(caller.nextQueuedFeature.title))


### PR DESCRIPTION
If a file is tagged in Kodi as Dolby TrueHD an additional check will be performed to see if its filename contains ".Atmos." (or similar). If so the audio format will be Dolby Atmos rather than Dolby TrueHD.

Similarly if a file is tagged in Kodi as DTS-HD Master Audio an additional check will be performed to see if its filename contains ".DTS.X." (or similar). If so the audio format will be DTS-X rathor than DTS-HD Master Audio.

In each case a regex is used to prevent false positives. When Kodi can detect and tag Atmos/DTS-X this code path can be safely removed without change in functionality.

See the discussion here for the pros and cons: http://cinemavision.tv/forums/topic/414-how-does-cinemavision-recognize-atmosdtsx-content-for-audio-bumpers/

I wasn't sure about the style, it didn't seem to be following PEP8 so I just winged it.