### PR TITLE
Update language string for skinners

### DIFF
--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -13,6 +13,10 @@ msgstr ""
 "Language: en\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 
+msgctxt "#32000"
+msgid "CinemaVision"
+msgstr ""
+
 msgctxt "#32001"
 msgid "General"
 msgstr ""


### PR DESCRIPTION
This would allow skinners to use `<label>$ADDON[script.cinemavision 32000]</label>` instead of having to update each skin's strings.po file in order to support CinemaVision.

This label is currently needed when DialogVideoInfo.xml is updated in a skin to support CinemaVision.